### PR TITLE
Update links to external resources

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,7 @@ class PackerVM < VM
   @@packer = {
     autostart: false,
     memory: 8192,
-    cpus: 4,
+    cpus: 2,
     linked_clone: false,
   }
 

--- a/ci.ps1
+++ b/ci.ps1
@@ -81,6 +81,9 @@ function MD5HashFile([string] $filePath)
     }
 }
 
+$timespamp = (Get-Date).tostring("yyyyMMddTHHmmss")
+$Env:PACKER_LOG_PATH = $Env:PACKER_LOG_PATH -replace ".txt", "$timespamp.txt"
+
 Write-Host "Preparing to run build script..."
 
 if(!$PSScriptRoot){

--- a/src/components/core/chef/Vagrantfile.kitchen.rb
+++ b/src/components/core/chef/Vagrantfile.kitchen.rb
@@ -1,6 +1,6 @@
 require "#{File.dirname(__FILE__)}/../vagrant/Vagrantfile.core"
 
-VM.core(memory: 8192, cpus: 4)
+VM.core(memory: 8192, cpus: 2)
 
 Environment.new(name: 'kitchen.local') do |environment|
   VM.new(environment) do |vm|

--- a/src/components/core/vagrant/Vagrantfile.core.rb
+++ b/src/components/core/vagrant/Vagrantfile.core.rb
@@ -61,7 +61,7 @@ class VM
     autostart: true,
     primary: false,
     memory: 8192,
-    cpus: 4,
+    cpus: 2,
     linked_clone: true,
   }
 

--- a/src/components/solr/chef/cookbooks/scp_solr/metadata.rb
+++ b/src/components/solr/chef/cookbooks/scp_solr/metadata.rb
@@ -7,5 +7,5 @@ long_description 'Installs/Configures SOLR Server'
 version '1.0.0'
 
 depends 'scp_windows'
-depends 'nssm', '~> 4.0.0'
+depends 'nssm', '~> 4.0.1'
 

--- a/src/components/sql/chef/cookbooks/scp_sql/attributes/2016_developer.rb
+++ b/src/components/sql/chef/cookbooks/scp_sql/attributes/2016_developer.rb
@@ -1,3 +1,3 @@
 default['scp_sql']['2016_developer'] = {
-  'installer_iso_url' => 'https://download.my.visualstudio.com/pr/en_sql_server_2016_developer_with_service_pack_1_x64_dvd_9548071.iso?t=53e1e739-a48f-4564-ba70-7015c768fc99&e=1528946790&h=82f22bdbfd0a9640a931666a6326f153&su=1',
+  'installer_iso_url' => 'https://download.my.visualstudio.com/db/en_sql_server_2016_developer_with_service_pack_2_x64_dvd_12194995.iso?t=3d6adc68-59c5-4daf-99ef-12e1deef4c79&e=1532478394&h=9a3a3ba361ff8d8bd69176f7d1effc4f&su=1',
 }

--- a/src/containers/sc900/packer/postprocessors/vagrant-virtualbox/Vagrantfile
+++ b/src/containers/sc900/packer/postprocessors/vagrant-virtualbox/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider 'virtualbox' do |vb|
     vb.memory = 8192
-    vb.cpus = 4
+    vb.cpus = 2
   end
 
   config.vm.network :forwarded_port, guest: 3389, host: 33389, auto_correct: true

--- a/src/containers/sc901/packer/postprocessors/vagrant-virtualbox/Vagrantfile
+++ b/src/containers/sc901/packer/postprocessors/vagrant-virtualbox/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider 'virtualbox' do |vb|
     vb.memory = 8192
-    vb.cpus = 4
+    vb.cpus = 2
   end
 
   config.vm.network :forwarded_port, guest: 3389, host: 33389, auto_correct: true

--- a/src/containers/sc902/packer/postprocessors/vagrant-virtualbox/Vagrantfile
+++ b/src/containers/sc902/packer/postprocessors/vagrant-virtualbox/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider 'virtualbox' do |vb|
     vb.memory = 8192
-    vb.cpus = 4
+    vb.cpus = 2
   end
 
   config.vm.network :forwarded_port, guest: 3389, host: 33389, auto_correct: true

--- a/src/containers/w/packer/builders/virtualbox/template.json
+++ b/src/containers/w/packer/builders/virtualbox/template.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "virtualbox_memory": "8192",
-    "virtualbox_cpus": "4",
+    "virtualbox_cpus": "2",
     "virtualbox_headless": "true",
     "virtualbox_boot_wait": "1m",
     "virtualbox_communicator": "winrm",

--- a/src/containers/w/packer/postprocessors/vagrant-virtualbox/Vagrantfile
+++ b/src/containers/w/packer/postprocessors/vagrant-virtualbox/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider 'virtualbox' do |vb|
     vb.memory = 8192
-    vb.cpus = 4
+    vb.cpus = 2
   end
 
   config.vm.network :forwarded_port, guest: 3389, host: 33389, auto_correct: true

--- a/src/containers/w16s/packer/builders/iso/template.json
+++ b/src/containers/w16s/packer/builders/iso/template.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "iso_url": "file:///d:/.downloads/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "iso_checksum_type": "sha1",
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3"
   }

--- a/src/containers/xc901/packer/postprocessors/vagrant-virtualbox/Vagrantfile
+++ b/src/containers/xc901/packer/postprocessors/vagrant-virtualbox/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider 'virtualbox' do |vb|
     vb.memory = 8192
-    vb.cpus = 4
+    vb.cpus = 2
   end
 
   config.vm.network :forwarded_port, guest: 3389, host: 33389, auto_correct: true

--- a/src/containers/xc901/packer/template.json
+++ b/src/containers/xc901/packer/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "name": "xc901",
     "description": "Sitecore Commerce 9.0.1",
-    "virtualbox_cpus": "6",
+    "virtualbox_cpus": "2",
     "virtualbox_memory": "16384"
   }
 }

--- a/src/core/cake/template.cake
+++ b/src/core/cake/template.cake
@@ -86,7 +86,7 @@ void PackerTemplate_Build(PackerTemplate template) {
     return;
   }
 
-  PackerTemplate_Packer(template, "build template.json");
+  PackerTemplate_Packer(template, "build -on-error=ask -color=true template.json");
 }
 
 void PackerTemplate_Rebuild(PackerTemplate template) {

--- a/tests/w16s-sc901/Vagrantfile
+++ b/tests/w16s-sc901/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure('2') do |config|
     vb.linked_clone = true
 
     # Customize the amount of memory on the VM:
-    vb.cpus = 4
+    vb.cpus = 2
     vb.memory = '8192'
 
     # clipboard

--- a/tests/w16s-sc902/Vagrantfile
+++ b/tests/w16s-sc902/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure('2') do |config|
     vb.linked_clone = true
 
     # Customize the amount of memory on the VM:
-    vb.cpus = 4
+    vb.cpus = 2
     vb.memory = '8192'
 
     # clipboard

--- a/tests/w16s-xc901/Vagrantfile
+++ b/tests/w16s-xc901/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure('2') do |config|
     vb.linked_clone = true
 
     # Customize the amount of memory on the VM:
-    vb.cpus = 4
+    vb.cpus = 2
     vb.memory = '8192'
 
     # clipboard


### PR DESCRIPTION
Update links to external resources: Windows ISO, SQL server.
Create log files with Timestamp in the name.
Change CPU to 2 by default, to work on i5