### PR TITLE
Configured CredSSP flag thru iso autounattend script

### DIFF
--- a/src/containers/w/packer/builders/iso/floppy/Autounattend.ps1
+++ b/src/containers/w/packer/builders/iso/floppy/Autounattend.ps1
@@ -22,6 +22,9 @@ wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE
 Write-Host "Configuring security zones"
 reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" /v 1806 /d 0 /t REG_DWORD /f /reg:64
 
+Write-Host "Configuring CredSSP encryption oracle remediation registry flag"
+reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters" /v AllowEncryptionOracle /t REG_DWORD /d 2
+
 Write-Host "Configuring WinRM"
 winrm quickconfig -q
 winrm quickconfig -transport:http


### PR DESCRIPTION
### Abstract

Host machines typically don't include [required](https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2018-0886) security updates. That causes certain issues for the users that use boxes for the first time or they just got new OS installed.

![image](https://user-images.githubusercontent.com/43253316/48318470-6d28f280-e612-11e8-9c24-0ab4d49fc220.png)

### Resolution

Since we deal with local dev env and we can afford fixing registry flag on the server side. The workaround for the server is described [here](https://support.microsoft.com/en-us/help/4295591/credssp-encryption-oracle-remediation-error-when-to-rdp-to-azure-vm). Fix is applied to autounattend script.