### PR TITLE
Implemented full credssp fix

### DIFF
--- a/src/containers/w/packer/builders/virtualbox/template.json
+++ b/src/containers/w/packer/builders/virtualbox/template.json
@@ -7,7 +7,7 @@
     "virtualbox_communicator": "winrm",
     "virtualbox_winrm_username": "vagrant",
     "virtualbox_winrm_password": "vagrant",
-    "virtualbox_winrm_timeout": "1h",
+    "virtualbox_winrm_timeout": "2h",
     "virtualbox_guest_additions_mode": "disable",
     "virtualbox_shutdown_command": "A:/shutdown.cmd",
     "virtualbox_post_shutdown_delay": "5s"

--- a/src/containers/w/packer/provisioners/chef/template.json
+++ b/src/containers/w/packer/provisioners/chef/template.json
@@ -69,18 +69,6 @@
       "skip_install": "{{user `chef_skip_install`}}",
       "staging_directory": "{{user `chef_staging_directory`}}",
       "remote_cookbook_paths": "{{user `chef_destination`}}/cookbooks",
-      "run_list": "{{user `chef_run_list_patch`}}"
-    },
-    {
-      "type": "windows-restart",
-      "restart_timeout": "{{user `chef_restart_timeout`}}"
-    },
-    {
-      "type": "chef-solo",
-      "guest_os_type": "{{user `chef_guest_os_type`}}",
-      "skip_install": "{{user `chef_skip_install`}}",
-      "staging_directory": "{{user `chef_staging_directory`}}",
-      "remote_cookbook_paths": "{{user `chef_destination`}}/cookbooks",
       "run_list": "{{user `chef_run_list_cleanup`}}"
     },
     {

--- a/src/containers/w16s/chef/cookbooks/scp_packer_w16s/recipes/patch.rb
+++ b/src/containers/w16s/chef/cookbooks/scp_packer_w16s/recipes/patch.rb
@@ -1,1 +1,13 @@
 include_recipe 'scp_packer_w::patch'
+
+scp_windows_updates 'Install update fixing Oracle encryption error' do
+  msu_source 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2018/05/windows10.0-kb4103723-x64_2adf2ea2d09b3052d241c40ba55e89741121e07e.msu'
+  action :install
+end
+
+scp_windows_powershell_script_elevated 'Set Oracle encryption policy to mitigated' do
+  code <<-EOH
+    reg add "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\CredSSP\\Parameters" /v AllowEncryptionOracle /t REG_DWORD /d 2 /f
+  EOH
+  action :run
+end


### PR DESCRIPTION
- added oracle remediation KB update + mitigation param #9 
- increased timeout to satisfy windows .msu cleanup procedure run time (dcim takes long)
- removed duplication in patch logic
