### PR TITLE
Fixes for Sitecore 9.0.x templates

### DIFF
--- a/src/components/sitecore/chef/cookbooks/scp_sitecore/chefignore
+++ b/src/components/sitecore/chef/cookbooks/scp_sitecore/chefignore
@@ -39,7 +39,7 @@ a.out
 *.so
 *.com
 *.class
-*.dll
+#*.dll # We have few DLLs to upload
 *.exe
 */rdoc/
 

--- a/src/components/sitecore/chef/cookbooks/scp_sitecore/resources/prepare.rb
+++ b/src/components/sitecore/chef/cookbooks/scp_sitecore/resources/prepare.rb
@@ -55,8 +55,8 @@ action :install_and_update_sif do
     code <<-EOH
       $ProgressPreference='SilentlyContinue';
       Register-PSRepository -Name SitecoreGallery -SourceLocation https://sitecore.myget.org/F/sc-powershell/api/v2 -InstallationPolicy Trusted;
-      Install-Module SitecoreInstallFramework;
-      Update-Module SitecoreInstallFramework;
+      Install-Module SitecoreInstallFramework -RequiredVersion 1.2.1 -Repository SitecoreGallery;
+      Update-Module SitecoreInstallFramework -RequiredVersion 1.2.1;
     EOH
     action :run
   end

--- a/src/components/virtualbox/chef/cookbooks/scp_virtualbox/attributes/guest_additions.rb
+++ b/src/components/virtualbox/chef/cookbooks/scp_virtualbox/attributes/guest_additions.rb
@@ -1,3 +1,3 @@
 default['scp_virtualbox']['guest_additions'] = {
-  'version' => '5.2.4',
+  'version' => '5.2.22',
 }

--- a/src/containers/sc902/packer/postprocessors/vagrant-virtualbox/Vagrantfile
+++ b/src/containers/sc902/packer/postprocessors/vagrant-virtualbox/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.hostname = "#{ENV['COMPUTERNAME']}-TSC901"
+  config.vm.hostname = "#{ENV['COMPUTERNAME']}-TSC902"
 
   config.vm.guest = :windows
   config.vm.communicator = 'winrm'

--- a/src/containers/w/packer/builders/virtualbox-iso/template.json
+++ b/src/containers/w/packer/builders/virtualbox-iso/template.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "virtualbox_guest_os_type": "",
-    "virtualbox_disk_size": "130048",
+    "virtualbox_disk_size": "61440",
     "virtualbox_floppy_files": "builders/virtualbox-iso/floppy"
   },
   "builders": [
@@ -24,6 +24,24 @@
           "{{.Name}}",
           "--cpus",
           "{{user `virtualbox_cpus`}}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "64"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--pae",
+          "off"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--paravirtprovider",
+          "hyperv"
         ]
       ],
       "disk_size": "{{user `virtualbox_disk_size`}}",

--- a/src/containers/w/packer/builders/virtualbox-ovf/template.json
+++ b/src/containers/w/packer/builders/virtualbox-ovf/template.json
@@ -20,6 +20,24 @@
           "{{.Name}}",
           "--cpus",
           "{{user `virtualbox_cpus`}}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "64"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--pae",
+          "off"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--paravirtprovider",
+          "hyperv"
         ]
       ],
       "floppy_files": "{{user `virtualbox_floppy_files`}}",

--- a/src/containers/w/packer/builders/virtualbox/template.json
+++ b/src/containers/w/packer/builders/virtualbox/template.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "virtualbox_memory": "8192",
-    "virtualbox_cpus": "2",
+    "virtualbox_cpus": "4",
     "virtualbox_headless": "true",
     "virtualbox_boot_wait": "1m",
     "virtualbox_communicator": "winrm",

--- a/src/containers/xc901/packer/template.json
+++ b/src/containers/xc901/packer/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "name": "xc901",
     "description": "Sitecore Commerce 9.0.1",
-    "virtualbox_cpus": "2",
+    "virtualbox_cpus": "4",
     "virtualbox_memory": "16384"
   }
 }

--- a/src/containers/xc902/packer/template.json
+++ b/src/containers/xc902/packer/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "name": "xc902",
     "description": "Sitecore Commerce 9.0.2",
-    "virtualbox_cpus": "6",
+    "virtualbox_cpus": "4",
     "virtualbox_memory": "16384"
   }
 }


### PR DESCRIPTION
Adjust chefignore to include dlls
Explicitly specify SIF to 1.2.1
Update Virtualbox guest-additions version to 5.2.4
Fix vagrantfile hostname
Add vboxmanage to packer templates: vram, pae, paravirtprovider
