### PR TITLE
TLS 1.2 shall be enabled by default

### DIFF
--- a/src/containers/w/packer/provisioners/chef/upload/prepare.ps1
+++ b/src/containers/w/packer/provisioners/chef/upload/prepare.ps1
@@ -1,3 +1,8 @@
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+Write-Host "Allowing TLS 1.2 to be used"
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord
+
 Write-Host "Installing Chef Client"
 # We might want to bump it later. Testing required
 choco install chef-client -y --version 13.4.24 #--version 15.0.300 --force


### PR DESCRIPTION
TLS 1.2 now default in the wild, so to be able to rebuild box from scratch - you have to set it as default on your VM as well